### PR TITLE
[🔄 Refactor] 프로필 수정 기본값 새로고침시 사라지는 것 해결

### DIFF
--- a/src/component/Navbar/Navbar.tsx
+++ b/src/component/Navbar/Navbar.tsx
@@ -85,8 +85,8 @@ export default function Navbar() {
               altText="profile"
               userId={user?.id || ''}
               size="xsmall"
+              to="/mypage"
               border="2px solid var(--color-black)"
-              disabledLink={true}
             />
           ) : (
             <Profile

--- a/src/pages/profileEdit/index.tsx
+++ b/src/pages/profileEdit/index.tsx
@@ -44,10 +44,10 @@ export function ProfileEdit() {
     handleSubmit,
     formState: { errors }
   } = useForm<FormData>({
-    defaultValues: userinfo
+    defaultValues: user
       ? {
-          nickname: userinfo[0].nickname,
-          introduction: userinfo[0].introduction
+          nickname: user?.nickname,
+          introduction: user?.introduction ?? undefined
         }
       : {}
   })

--- a/src/pages/profileEdit/index.tsx
+++ b/src/pages/profileEdit/index.tsx
@@ -22,6 +22,7 @@ export function ProfileEdit() {
 
   // data get는 커스텀훅으로 처리
   const { userinfo } = useUserInfo()
+
   // data edit
   const { mutate } = useMutation({
     mutationFn: ({

--- a/src/pages/profileEdit/index.tsx
+++ b/src/pages/profileEdit/index.tsx
@@ -96,7 +96,7 @@ export function ProfileEdit() {
     mutate({ data: editProfileData, image: newImage, id: userId })
 
     updateUser({
-      profile_img: newImage,
+      profile_img: userinfo![0].profile_img,
       nickname: editProfileData.nickname,
       introduction: editProfileData.introduction
     })

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,7 +5,7 @@ interface User {
   id: string
   email: string
   nickname: string
-  profile_img: string | FileList | undefined | null
+  profile_img: string | undefined | null
   introduction?: string | null
   subsc_count?: number
 }

--- a/src/types/profileEdit.ts
+++ b/src/types/profileEdit.ts
@@ -4,7 +4,7 @@ export type FormData = {
   introduction: string
 }
 
-export interface EditProfile {
+export type EditProfile = {
   image?: FileList | null
   nickname?: string
   introduction?: string


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #115 

## 📋 작업 내용

- 프로필 수정 기본값 새로고침시 사라지는 것 해결
- store내의 user의 profile_img 업데이트처리 변경
