### PR TITLE
[🐛 Bug] 플리 상세페이지에서 댓글 수가 실시간으로 반영되지 않는 이슈 #120

### DIFF
--- a/src/hooks/useDeleteComment.ts
+++ b/src/hooks/useDeleteComment.ts
@@ -10,6 +10,9 @@ const useDeleteComment = () => {
       queryClient.invalidateQueries({
         queryKey: ['playlistComments', variables.playlistId]
       })
+      queryClient.invalidateQueries({
+        queryKey: ['playlist', variables.playlistId]
+      })
     }
   })
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #120 

> close #120 

## 📋 작업 내용

댓글 삭제 시 댓글 수가 실시간으로 반영되지 않는 이슈
원인: 댓글 삭제 훅에서 playlist 테이블을 실시간으로 업데이트해줘야하는데(정확히는 캐시 삭제) 그 부분 빠트림