### PR TITLE
[🐛 Bug] 내 플레이리스트 삭제 실패 이슈

### DIFF
--- a/src/component/ErrorBoundary/ErrorFallback.tsx
+++ b/src/component/ErrorBoundary/ErrorFallback.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import * as S from './ErrorFallback.styles'
 
 interface ErrorFallbackProps {
@@ -9,11 +10,17 @@ export function ErrorFallback({
   error,
   resetErrorBoundary
 }: ErrorFallbackProps) {
+  const navigate = useNavigate()
+
+  const handleGoHome = () => {
+    resetErrorBoundary()
+    navigate('/')
+  }
   return (
     <S.ErrorContainer role="alert">
       <S.ErrorTitle>문제가 발생했습니다</S.ErrorTitle>
       <S.ErrorMessage>{error.message}</S.ErrorMessage>
-      <S.ResetButton onClick={resetErrorBoundary}>다시 시도하기</S.ResetButton>
+      <S.ResetButton onClick={handleGoHome}>홈으로 이동</S.ResetButton>
     </S.ErrorContainer>
   )
 }

--- a/src/component/Input/Input.tsx
+++ b/src/component/Input/Input.tsx
@@ -47,4 +47,9 @@ const StyledInput = styled.input<
   width: ${props => props.width || '100%'};
   height: ${props => props.height || 'auto'};
   ${props => !props.isCustom && mainStyle};
+
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px #fff inset !important;
+    box-shadow: 0 0 0 1000px #fff inset !important;
+  }
 `

--- a/src/component/MyPlayList/MyPlayList.styles.ts
+++ b/src/component/MyPlayList/MyPlayList.styles.ts
@@ -12,15 +12,15 @@ export const Title = styled.p`
   font-weight: 500;
   color: var(--color-black);
   padding: var(--spacing-4) 0;
+  display: flex;
+  align-items: start;
+
   span {
     font-size: var(--fs-xl);
-    display: inline-block;
     max-width: 200px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    text-align: center;
-    vertical-align: middle;
   }
 `
 export const PlayListWrapper = styled.div`

--- a/src/component/PlayListCreate/PlayListCreate.styles.ts
+++ b/src/component/PlayListCreate/PlayListCreate.styles.ts
@@ -154,14 +154,15 @@ export const ThumbnailTitle = styled.p`
   font-size: var(--fs-l);
   font-weight: 600;
   color: var(--color-black);
-  padding: var(--spacing-2);
+  margin-top: var(--spacing-4);
+  padding: 0 var(--spacing-3);
   ${TextEllipsis}
 `
 export const ThumbnailMaker = styled.p`
   font-size: var(--fs-m);
   font-weight: 500;
   color: var(--color-black);
-  padding-left: var(--spacing-2);
+  padding: var(--spacing-3);
   ${TextEllipsis}
 `
 export const TrackTag = styled.div`

--- a/src/pages/view/index.tsx
+++ b/src/pages/view/index.tsx
@@ -34,6 +34,7 @@ import useFetchVideoList from '@/hooks/useFetchVideoList'
 import { LAST_VIDEO_TITLE } from '@/constants/constant'
 import axiosInstance from '@/apis/axiosInstance'
 import { dateKoreanFormat } from '@/utils/dateKoreanFormat'
+import WritingHashtags from '@/utils/writingHashtags'
 
 const DescriptionText = ({ description }: Pick<IViewProps, 'description'>) => {
   const textRef = useRef<HTMLDivElement>(null)
@@ -52,7 +53,7 @@ const DescriptionText = ({ description }: Pick<IViewProps, 'description'>) => {
         <div
           className={`desc-text ${isOpen ? 'open' : ''}`}
           ref={textRef}>
-          {description}
+          <WritingHashtags description={description} />
         </div>
         {isOverflow && (
           <span className="desc-toggle-text">

--- a/src/utils/writingHashtags.tsx
+++ b/src/utils/writingHashtags.tsx
@@ -1,6 +1,4 @@
 import React from 'react'
-import * as S from '@/component/PlayListCreate/PlayListCreate.styles'
-
 interface WritingHashtagsProps {
   description: string
 }
@@ -19,9 +17,10 @@ const WritingHashtags = ({ description }: WritingHashtagsProps) => {
         const processedLine = parts.map((part, partIndex) => {
           if (part.startsWith('#')) {
             return (
-              <S.HashtagSpan key={`${lineIndex}-${partIndex}`}>
-                {part}
-              </S.HashtagSpan>
+              <HashtagSpan key={`${lineIndex}-${partIndex}`}>
+                <span className="hash-symbol">#</span>
+                <span className="hash-text">{part.slice(1)}</span>
+              </HashtagSpan>
             )
           }
           return part
@@ -39,3 +38,9 @@ const WritingHashtags = ({ description }: WritingHashtagsProps) => {
 }
 
 export default WritingHashtags
+import styled from 'styled-components'
+
+export const HashtagSpan = styled.span`
+  color: var(--color-main1);
+  font-weight: 500;
+`


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #123

## 📋 작업 내용

- 내플리 삭제 실패는 supabase에서 연결되어있던 comments도 같이 삭제하게해서 해결하였습니다. 
- 내플리에서 닉네임"의 플레이리스트" 한줄처럼 보이게끔 css 수정했고
- 생성에서는 #일상 쓰면 색상 변경되도록해서 상세페이지에서도 사용했던 util함수로 적용했습니다 
@KwonSeami 해당파일 확인해주세요~!
- 로그인때문에 input 에서 자동완성 파란색배경되는 브라우저기본css 막았고
- 내플리에서 최신이 위로가도록 supabase로 수정했습니다.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/5370f821-64c9-4d7c-b7a8-424e9ab01d64)
![image](https://github.com/user-attachments/assets/5deea1e2-7b15-4072-9163-dcab260782b0)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
