### PR TITLE
[🐛 Bug] 프로필 수정시 최신 이미지 업데이트 store에 반영 안되는 이슈

### DIFF
--- a/src/pages/profileEdit/index.tsx
+++ b/src/pages/profileEdit/index.tsx
@@ -3,7 +3,7 @@ import * as S from './EditProfile.styled'
 import { Profile, Input, Button } from '@/component'
 import img from '@/assets/img/profile/default_profile.png'
 import { useForm } from 'react-hook-form'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { UserProfileEdit } from '@/apis/userInfoApi'
 import { useAuthStore } from '@/store/useAuthStore'
 import { CiCirclePlus } from 'react-icons/ci'
@@ -22,6 +22,8 @@ export function ProfileEdit() {
   // data get는 커스텀훅으로 처리
   const { userinfo } = useUserInfo()
 
+  const queryClient = useQueryClient()
+
   // data edit
   const { mutate } = useMutation({
     mutationFn: ({
@@ -33,11 +35,29 @@ export function ProfileEdit() {
       image: string | FileList | null
       id: string
     }) => UserProfileEdit(data, image, id),
-
     onSuccess: () => {
       handleToastSuccess(`수정되었습니다!!`)
-    },
 
+      queryClient
+        .refetchQueries({ queryKey: ['userInfo', user?.id] })
+        .then(() => {
+          const updatedUserInfo = queryClient.getQueryData<
+            {
+              profile_img: string
+              nickname: string
+              introduction: string
+            }[]
+          >(['userInfo', user?.id])
+
+          if (updatedUserInfo) {
+            updateUser({
+              profile_img: updatedUserInfo[0].profile_img,
+              nickname: updatedUserInfo[0].nickname,
+              introduction: updatedUserInfo[0].introduction
+            })
+          }
+        })
+    },
     onError: () => handleToastError(`수정에 실패하였습니다... `)
   })
 
@@ -96,13 +116,6 @@ export function ProfileEdit() {
     }
 
     mutate({ data: editProfileData, image: newImage, id: userId })
-
-    updateUser({
-      profile_img: userinfo![0].profile_img,
-      nickname: editProfileData.nickname,
-      introduction: editProfileData.introduction
-    })
-
     navigate('/mypage')
   }
 

--- a/src/pages/profileEdit/index.tsx
+++ b/src/pages/profileEdit/index.tsx
@@ -9,12 +9,14 @@ import { useAuthStore } from '@/store/useAuthStore'
 import { CiCirclePlus } from 'react-icons/ci'
 import { useUserInfo, useToast } from '@/hooks'
 import { FormData, EditProfile } from '@/types/profileEdit'
+import { useNavigate } from 'react-router-dom'
 
 export function ProfileEdit() {
+  const [image, setImage] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const navigate = useNavigate()
   const { user, updateUser } = useAuthStore()
   const userId = user?.id
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [image, setImage] = useState<string | null>(null)
   const { handleToastError, handleToastSuccess } = useToast()
 
   // data get는 커스텀훅으로 처리
@@ -31,7 +33,10 @@ export function ProfileEdit() {
       image: string | FileList | null
       id: string
     }) => UserProfileEdit(data, image, id),
-    onSuccess: () => handleToastSuccess(`수정되었습니다!! `),
+
+    onSuccess: () => {
+      handleToastSuccess(`수정되었습니다!!`)
+    },
 
     onError: () => handleToastError(`수정에 실패하였습니다... `)
   })
@@ -97,6 +102,8 @@ export function ProfileEdit() {
       nickname: editProfileData.nickname,
       introduction: editProfileData.introduction
     })
+
+    navigate('/mypage')
   }
 
   return (
@@ -160,14 +167,9 @@ export function ProfileEdit() {
         <S.ContentBox>
           <Input
             id="introduction"
-            {...register('introduction', {
-              required: '소개 글을 입력해주세요.'
-            })}
+            {...register('introduction')}
             placeholder="소개 글을 입력해주세요"
           />
-          {errors.introduction && (
-            <S.Errormsg>{errors.introduction.message}</S.Errormsg>
-          )}
         </S.ContentBox>
         <S.CompleteBox>
           <Button


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #129 

## 📋 작업 내용

 - 프로필 이미지 수정 최신것 store에 반영하기. (프로필 사진 변경 후, 코멘트에 있는 프로필에서 확인가능)
    - queryClient의 refetchQueries 메소드 사용
  
 - 소개글 필수요건에서 제거
 - 수정누르면 다시 마이페이지로 이동하기.
