### PR TITLE
[🔄 Refactor] 유저 프로필 헤더,스타일 변경 및 플레이리스트 정렬

### DIFF
--- a/src/apis/userInfoApi.ts
+++ b/src/apis/userInfoApi.ts
@@ -116,16 +116,18 @@ export async function DeleteLikeList(
   return data
 }
 
-//저장된 플레이리스트 정보
 export async function SavedPlayList(
   userId: string | undefined,
   pageParam: number = 1
 ) {
   const PAGE_SIZE = 10
+
+  // 북마크 테이블에서 해당 사용자의 playlist_id를 가져옵니다.
   const { data: savedPlaylists, error } = await supabase
     .from('bookmarks')
-    .select('playlist_id')
+    .select('playlist_id, created_at') // 북마크 생성 시점도 가져옵니다.
     .eq('user_id', userId)
+    .order('created_at', { ascending: false }) // 북마크 생성 시점 기준 내림차순 정렬
 
   if (error) {
     console.error(error)
@@ -134,11 +136,14 @@ export async function SavedPlayList(
 
   const playlistIds = savedPlaylists.map(item => item.playlist_id)
 
+  // playlists 테이블에서 playlist_id를 기반으로 플레이리스트 정보를 가져옵니다.
+  // 추가적으로 playlist의 created_at 기준으로 내림차순 정렬
   const { data: playlists, error: playlistError } = await supabase
     .from('playlists')
     .select('*')
     .in('playlist_id', playlistIds)
-    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1)
+    .order('created_at', { ascending: false }) // 플레이리스트 생성 시점 기준 내림차순 정렬
+    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1) // 페이지네이션 처리
 
   if (playlistError) {
     console.error(playlistError)

--- a/src/apis/userInfoApi.ts
+++ b/src/apis/userInfoApi.ts
@@ -71,8 +71,9 @@ export async function LikedPlayList(
   const PAGE_SIZE = 10
   const { data: likedPlaylists, error } = await supabase
     .from('likes')
-    .select('playlist_id')
+    .select('playlist_id, created_at')
     .eq('user_id', userId)
+    .order('created_at', { ascending: false })
 
   if (error) {
     console.error(error)
@@ -94,7 +95,19 @@ export async function LikedPlayList(
     )
   }
 
-  return playlists
+  const sortedLikeList = likedPlaylists
+    .map(cur => {
+      const playlist = playlists.find(
+        cur2 => cur2.playlist_id === cur.playlist_id
+      )
+      if (playlist) {
+        return { ...playlist, likes_created_at: cur.created_at }
+      }
+      return null
+    })
+    .filter(item => item !== null)
+
+  return sortedLikeList
 }
 
 //좋아요 리스트 삭제
@@ -122,12 +135,11 @@ export async function SavedPlayList(
 ) {
   const PAGE_SIZE = 10
 
-  // 북마크 테이블에서 해당 사용자의 playlist_id를 가져옵니다.
   const { data: savedPlaylists, error } = await supabase
     .from('bookmarks')
-    .select('playlist_id, created_at') // 북마크 생성 시점도 가져옵니다.
+    .select('playlist_id, created_at')
     .eq('user_id', userId)
-    .order('created_at', { ascending: false }) // 북마크 생성 시점 기준 내림차순 정렬
+    .order('created_at', { ascending: false })
 
   if (error) {
     console.error(error)
@@ -136,14 +148,11 @@ export async function SavedPlayList(
 
   const playlistIds = savedPlaylists.map(item => item.playlist_id)
 
-  // playlists 테이블에서 playlist_id를 기반으로 플레이리스트 정보를 가져옵니다.
-  // 추가적으로 playlist의 created_at 기준으로 내림차순 정렬
   const { data: playlists, error: playlistError } = await supabase
     .from('playlists')
     .select('*')
     .in('playlist_id', playlistIds)
-    .order('created_at', { ascending: false }) // 플레이리스트 생성 시점 기준 내림차순 정렬
-    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1) // 페이지네이션 처리
+    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1)
 
   if (playlistError) {
     console.error(playlistError)
@@ -152,7 +161,19 @@ export async function SavedPlayList(
     )
   }
 
-  return playlists
+  const sortedPlaylists = savedPlaylists
+    .map(saved => {
+      const playlist = playlists.find(
+        playlist => playlist.playlist_id === saved.playlist_id
+      )
+      if (playlist) {
+        return { ...playlist, bookmark_created_at: saved.created_at }
+      }
+      return null
+    })
+    .filter(item => item !== null)
+
+  return sortedPlaylists
 }
 
 //저장된 리스트 삭제

--- a/src/component/Layout/Layout.tsx
+++ b/src/component/Layout/Layout.tsx
@@ -48,9 +48,13 @@ const Layout = () => {
     ROUTER_PATH.VIEW
   ]
   const backHeaderPaths = ROUTER_PATH_REGEX.VIEW.test(location.pathname)
+  const secondBackHeaderPaths = ROUTER_PATH_REGEX.USERPROFILE.test(
+    location.pathname
+  )
 
   const isNoHeaderPaths = noHeaderPaths.includes(location.pathname)
   const isBackHeaderPaths = backHeaderPaths
+  const isSecondBackHeaderPaths = secondBackHeaderPaths
   const isNoNavbarPaths =
     noNavbarPaths.includes(location.pathname) ||
     ROUTER_PATH_REGEX.VIEW.test(location.pathname)
@@ -68,6 +72,8 @@ const Layout = () => {
     if (isSubHeaderPaths) {
       return <HeaderSub />
     } else if (isBackHeaderPaths) {
+      return <Header isBack={true} />
+    } else if (isSecondBackHeaderPaths) {
       return <Header isBack={true} />
     } else if (isNoHeaderPaths) {
       return null

--- a/src/pages/mypage/Mypage.styled.ts
+++ b/src/pages/mypage/Mypage.styled.ts
@@ -48,12 +48,18 @@ export const SubscribeCount = styled.div`
   font-weight: 500;
 `
 
+export const SubscribeCountForOthers = styled.div`
+  padding: var(--spacing-1) 0 var(--spacing-6) 0;
+  font-size: var(--fs-m);
+  font-weight: 500;
+`
+
 export const ButtonBox = styled.div`
   margin-bottom: var(--spacing-6);
 `
 
 export const IntruductionBox = styled.div`
-  padding: 0 0 var(--spacing-7) 0;
+  padding: var(--spacing-2) 0;
   font-size: var(--fs-l);
   text-align: center;
 `

--- a/src/pages/mypage/Mypage.styled.ts
+++ b/src/pages/mypage/Mypage.styled.ts
@@ -11,6 +11,11 @@ export const HeaderBox = styled.div`
   align-items: center;
   padding-top: var(--spacing-4);
 `
+
+export const HeaderBoxForOther = styled.div`
+  align-items: center;
+`
+
 export const logout = styled.div`
   position: absolute;
   top: 0;
@@ -48,8 +53,9 @@ export const ButtonBox = styled.div`
 `
 
 export const IntruductionBox = styled.div`
-  padding: var(--spacing-1) 0;
+  padding: 0 0 var(--spacing-7) 0;
   font-size: var(--fs-l);
+  text-align: center;
 `
 
 export const SeparatingBox = styled.div`

--- a/src/pages/userProfile/index.tsx
+++ b/src/pages/userProfile/index.tsx
@@ -25,12 +25,13 @@ export function UserProfile() {
           />
           <S.ProfileDetailBox>
             <S.UserName>{data?.[0]?.nickname}</S.UserName>
-            <S.SubscribeCount>{data?.[0]?.subsc_count} 구독자</S.SubscribeCount>
+            <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
+            <S.SubscribeCountForOthers>
+              {data?.[0]?.subsc_count} 구독자
+            </S.SubscribeCountForOthers>
           </S.ProfileDetailBox>
         </S.ProfileBox>
-        <S.ButtonBox></S.ButtonBox>
       </S.HeaderBoxForOther>
-      <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
 
       <S.SeparatingBox>
         <S.ShowTypes>플레이리스트</S.ShowTypes>

--- a/src/pages/userProfile/index.tsx
+++ b/src/pages/userProfile/index.tsx
@@ -15,7 +15,7 @@ export function UserProfile() {
 
   return (
     <S.Container>
-      <S.HeaderBox>
+      <S.HeaderBoxForOther>
         <S.ProfileBox>
           <Profile
             className="profile-img"
@@ -29,7 +29,7 @@ export function UserProfile() {
           </S.ProfileDetailBox>
         </S.ProfileBox>
         <S.ButtonBox></S.ButtonBox>
-      </S.HeaderBox>
+      </S.HeaderBoxForOther>
       <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
 
       <S.SeparatingBox>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #148 

## 📋 작업 내용

- 유저 프로필 스타일 배치를 프로필과 유사하게 하였습니다. (header도 바꿨어요. 뒤로가기가 필요하다고 생각합니다)
- 좋아요. 저장 플레이리스트 정렬을 supabase에서 해결하지 못해서 api함수에서 해결했습니다. / 혼자 해봐도 안돼서 gpt의 힘을 빌려서 해봤는데 sql메소드랑 결합되니 이게 사실 어떻게 정렬되는건지 이해가 되진 않네요 😭

## 📸 스크린샷 (선택 사항)
![스샷스샷스샷](https://github.com/user-attachments/assets/0bee2077-13ba-4118-91b3-5c01eedd053c)

## 📄 기타

구독버튼에 대해서 생각해봤는데, 유저프로필에서도 구독이 가능하게 하는게 맞다고 생각이드네요... 보면 볼수록 개선사항만 늘어갑니다
