### PR TITLE
[✨ Feature] 유저프로필 구독버튼 추가 

### DIFF
--- a/src/apis/userInfoApi.ts
+++ b/src/apis/userInfoApi.ts
@@ -116,16 +116,18 @@ export async function DeleteLikeList(
   return data
 }
 
-//저장된 플레이리스트 정보
 export async function SavedPlayList(
   userId: string | undefined,
   pageParam: number = 1
 ) {
   const PAGE_SIZE = 10
+
+  // 북마크 테이블에서 해당 사용자의 playlist_id를 가져옵니다.
   const { data: savedPlaylists, error } = await supabase
     .from('bookmarks')
-    .select('playlist_id')
+    .select('playlist_id, created_at') // 북마크 생성 시점도 가져옵니다.
     .eq('user_id', userId)
+    .order('created_at', { ascending: false }) // 북마크 생성 시점 기준 내림차순 정렬
 
   if (error) {
     console.error(error)
@@ -134,11 +136,14 @@ export async function SavedPlayList(
 
   const playlistIds = savedPlaylists.map(item => item.playlist_id)
 
+  // playlists 테이블에서 playlist_id를 기반으로 플레이리스트 정보를 가져옵니다.
+  // 추가적으로 playlist의 created_at 기준으로 내림차순 정렬
   const { data: playlists, error: playlistError } = await supabase
     .from('playlists')
     .select('*')
     .in('playlist_id', playlistIds)
-    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1)
+    .order('created_at', { ascending: false }) // 플레이리스트 생성 시점 기준 내림차순 정렬
+    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1) // 페이지네이션 처리
 
   if (playlistError) {
     console.error(playlistError)

--- a/src/apis/userInfoApi.ts
+++ b/src/apis/userInfoApi.ts
@@ -71,8 +71,9 @@ export async function LikedPlayList(
   const PAGE_SIZE = 10
   const { data: likedPlaylists, error } = await supabase
     .from('likes')
-    .select('playlist_id')
+    .select('playlist_id, created_at')
     .eq('user_id', userId)
+    .order('created_at', { ascending: false })
 
   if (error) {
     console.error(error)
@@ -94,7 +95,19 @@ export async function LikedPlayList(
     )
   }
 
-  return playlists
+  const sortedLikeList = likedPlaylists
+    .map(cur => {
+      const playlist = playlists.find(
+        cur2 => cur2.playlist_id === cur.playlist_id
+      )
+      if (playlist) {
+        return { ...playlist, likes_created_at: cur.created_at }
+      }
+      return null
+    })
+    .filter(item => item !== null)
+
+  return sortedLikeList
 }
 
 //좋아요 리스트 삭제
@@ -122,12 +135,11 @@ export async function SavedPlayList(
 ) {
   const PAGE_SIZE = 10
 
-  // 북마크 테이블에서 해당 사용자의 playlist_id를 가져옵니다.
   const { data: savedPlaylists, error } = await supabase
     .from('bookmarks')
-    .select('playlist_id, created_at') // 북마크 생성 시점도 가져옵니다.
+    .select('playlist_id, created_at')
     .eq('user_id', userId)
-    .order('created_at', { ascending: false }) // 북마크 생성 시점 기준 내림차순 정렬
+    .order('created_at', { ascending: false })
 
   if (error) {
     console.error(error)
@@ -136,14 +148,11 @@ export async function SavedPlayList(
 
   const playlistIds = savedPlaylists.map(item => item.playlist_id)
 
-  // playlists 테이블에서 playlist_id를 기반으로 플레이리스트 정보를 가져옵니다.
-  // 추가적으로 playlist의 created_at 기준으로 내림차순 정렬
   const { data: playlists, error: playlistError } = await supabase
     .from('playlists')
     .select('*')
     .in('playlist_id', playlistIds)
-    .order('created_at', { ascending: false }) // 플레이리스트 생성 시점 기준 내림차순 정렬
-    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1) // 페이지네이션 처리
+    .range((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE - 1)
 
   if (playlistError) {
     console.error(playlistError)
@@ -152,7 +161,19 @@ export async function SavedPlayList(
     )
   }
 
-  return playlists
+  const sortedPlaylists = savedPlaylists
+    .map(saved => {
+      const playlist = playlists.find(
+        playlist => playlist.playlist_id === saved.playlist_id
+      )
+      if (playlist) {
+        return { ...playlist, bookmark_created_at: saved.created_at }
+      }
+      return null
+    })
+    .filter(item => item !== null)
+
+  return sortedPlaylists
 }
 
 //저장된 리스트 삭제

--- a/src/component/Layout/Layout.tsx
+++ b/src/component/Layout/Layout.tsx
@@ -48,9 +48,13 @@ const Layout = () => {
     ROUTER_PATH.VIEW
   ]
   const backHeaderPaths = ROUTER_PATH_REGEX.VIEW.test(location.pathname)
+  const secondBackHeaderPaths = ROUTER_PATH_REGEX.USERPROFILE.test(
+    location.pathname
+  )
 
   const isNoHeaderPaths = noHeaderPaths.includes(location.pathname)
   const isBackHeaderPaths = backHeaderPaths
+  const isSecondBackHeaderPaths = secondBackHeaderPaths
   const isNoNavbarPaths =
     noNavbarPaths.includes(location.pathname) ||
     ROUTER_PATH_REGEX.VIEW.test(location.pathname)
@@ -68,6 +72,8 @@ const Layout = () => {
     if (isSubHeaderPaths) {
       return <HeaderSub />
     } else if (isBackHeaderPaths) {
+      return <Header isBack={true} />
+    } else if (isSecondBackHeaderPaths) {
       return <Header isBack={true} />
     } else if (isNoHeaderPaths) {
       return null

--- a/src/pages/mypage/Mypage.styled.ts
+++ b/src/pages/mypage/Mypage.styled.ts
@@ -48,12 +48,18 @@ export const SubscribeCount = styled.div`
   font-weight: 500;
 `
 
+export const SubscribeCountForOthers = styled.div`
+  padding: var(--spacing-1) 0 var(--spacing-6) 0;
+  font-size: var(--fs-m);
+  font-weight: 500;
+`
+
 export const ButtonBox = styled.div`
   margin-bottom: var(--spacing-6);
 `
 
 export const IntruductionBox = styled.div`
-  padding: 0 0 var(--spacing-7) 0;
+  padding: var(--spacing-2) 0;
   font-size: var(--fs-l);
   text-align: center;
 `

--- a/src/pages/mypage/Mypage.styled.ts
+++ b/src/pages/mypage/Mypage.styled.ts
@@ -11,6 +11,11 @@ export const HeaderBox = styled.div`
   align-items: center;
   padding-top: var(--spacing-4);
 `
+
+export const HeaderBoxForOther = styled.div`
+  align-items: center;
+`
+
 export const logout = styled.div`
   position: absolute;
   top: 0;
@@ -48,8 +53,9 @@ export const ButtonBox = styled.div`
 `
 
 export const IntruductionBox = styled.div`
-  padding: var(--spacing-1) 0;
+  padding: 0 0 var(--spacing-7) 0;
   font-size: var(--fs-l);
+  text-align: center;
 `
 
 export const SeparatingBox = styled.div`

--- a/src/pages/mypage/Mypage.styled.ts
+++ b/src/pages/mypage/Mypage.styled.ts
@@ -48,12 +48,6 @@ export const SubscribeCount = styled.div`
   font-weight: 500;
 `
 
-export const SubscribeCountForOthers = styled.div`
-  padding: var(--spacing-1) 0 var(--spacing-6) 0;
-  font-size: var(--fs-m);
-  font-weight: 500;
-`
-
 export const ButtonBox = styled.div`
   margin-bottom: var(--spacing-6);
 `
@@ -83,6 +77,15 @@ export const ShowTypes = styled.button<{ isActive?: boolean }>`
     border-bottom: 0.2rem solid var(--color-main1);
   `}
 `
+
+export const PlayListBoxForOther = styled.div`
+  margin-top: var(--spacing-5);
+  font-size: var(--fs-xl);
+  font-weight: 500;
+  cursor: pointer;
+  padding-bottom: var(--spacing-5);
+`
+
 export const PlayListsBox = styled.div`
   display: flex;
   flex-direction: column;
@@ -93,4 +96,22 @@ export const NotFound = styled.div`
   margin: 0 auto;
   font-size: var(--fs-xl);
   font-weight: 700;
+`
+
+export const StyledButton = styled.button`
+  flex: 0 0 auto;
+  width: auto;
+  padding: 0.8rem 1.6rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--color-white);
+  background: var(--color-black);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-black);
+
+  &.subsc-cancel {
+    padding: 0.8rem 1rem;
+    background: var(--color-white);
+    color: var(--color-black);
+  }
 `

--- a/src/pages/userProfile/index.tsx
+++ b/src/pages/userProfile/index.tsx
@@ -25,12 +25,13 @@ export function UserProfile() {
           />
           <S.ProfileDetailBox>
             <S.UserName>{data?.[0]?.nickname}</S.UserName>
-            <S.SubscribeCount>{data?.[0]?.subsc_count} 구독자</S.SubscribeCount>
+            <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
+            <S.SubscribeCountForOthers>
+              {data?.[0]?.subsc_count} 구독자
+            </S.SubscribeCountForOthers>
           </S.ProfileDetailBox>
         </S.ProfileBox>
-        <S.ButtonBox></S.ButtonBox>
       </S.HeaderBoxForOther>
-      <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
 
       <S.SeparatingBox>
         <S.ShowTypes>플레이리스트</S.ShowTypes>

--- a/src/pages/userProfile/index.tsx
+++ b/src/pages/userProfile/index.tsx
@@ -1,6 +1,6 @@
 import { userInfoGet } from '@/apis/userInfoApi'
 import UserProfileList from '@/component/MyPageType/UserProfileList'
-import { Button, Profile } from '@/component'
+import { Button, Loading, Profile } from '@/component'
 import * as S from '@/pages/mypage/Mypage.styled'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
@@ -21,7 +21,7 @@ export function UserProfile() {
 
   const { data: isSubsc } = useFetchUserSubscStatus(
     currentUser!.id,
-    data?.[0].id
+    data?.[0]?.id
   )
 
   const { mutate: toggleSubscMutate, isPending: isToggleSubscPending } =
@@ -44,8 +44,13 @@ export function UserProfile() {
   }
 
   if (isPending) {
-    return <div>잠시만 기다려주세요!</div>
+    return <Loading />
   }
+
+  if (!data?.[0]?.id) {
+    return <div>데이터가 페칭되고있지 않아요...</div>
+  }
+
   if (isError) {
     return <div>에러가 발생했어요...</div>
   }
@@ -71,14 +76,16 @@ export function UserProfile() {
                   type="button"
                   className="subsc-cancel"
                   onClick={handleSubscClick}
-                  disabled={isToggleSubscPending}>
-                  구독 취소
+                  disabled={isToggleSubscPending}
+                  width="70%">
+                  구독취소
                 </Button>
               ) : (
                 <Button
                   type="button"
                   onClick={handleSubscClick}
-                  disabled={isToggleSubscPending}>
+                  disabled={isToggleSubscPending}
+                  width="70%">
                   구독
                 </Button>
               ))}

--- a/src/pages/userProfile/index.tsx
+++ b/src/pages/userProfile/index.tsx
@@ -15,7 +15,7 @@ export function UserProfile() {
 
   return (
     <S.Container>
-      <S.HeaderBox>
+      <S.HeaderBoxForOther>
         <S.ProfileBox>
           <Profile
             className="profile-img"
@@ -29,7 +29,7 @@ export function UserProfile() {
           </S.ProfileDetailBox>
         </S.ProfileBox>
         <S.ButtonBox></S.ButtonBox>
-      </S.HeaderBox>
+      </S.HeaderBoxForOther>
       <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
 
       <S.SeparatingBox>

--- a/src/pages/userProfile/index.tsx
+++ b/src/pages/userProfile/index.tsx
@@ -1,17 +1,54 @@
 import { userInfoGet } from '@/apis/userInfoApi'
 import UserProfileList from '@/component/MyPageType/UserProfileList'
-import { Profile } from '@/component'
+import { Button, Profile } from '@/component'
 import * as S from '@/pages/mypage/Mypage.styled'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
+import { useAuthStore } from '@/store/useAuthStore'
+import useFetchUserSubscStatus from '@/hooks/useFetchUserSubscStatus'
+import useToggleSubsc from '@/hooks/useToggleSubsc'
+import { useToastMessageContext } from '@/providers/ToastMessageProvider'
 
 export function UserProfile() {
   const { userId } = useParams<{ userId: string }>()
+  const { user: currentUser } = useAuthStore()
+  const { showToastMessage } = useToastMessageContext()
 
-  const { data } = useQuery({
+  const { data, isPending, isError } = useQuery({
     queryKey: ['user', userId],
     queryFn: () => userInfoGet(userId)
   })
+
+  const { data: isSubsc } = useFetchUserSubscStatus(
+    currentUser!.id,
+    data?.[0].id
+  )
+
+  const { mutate: toggleSubscMutate, isPending: isToggleSubscPending } =
+    useToggleSubsc()
+
+  const handleSubscClick = () => {
+    const props = {
+      currentUserId: currentUser!.id,
+      subscribedUserId: data?.[0].id
+    }
+    toggleSubscMutate(props, {
+      onError: () => {
+        showToastMessage({
+          message:
+            '구독에 실패하였습니다. 새로고침 이후에도 문제가 지속될 경우 관리자에 문의해 주세요.',
+          type: 'error'
+        })
+      }
+    })
+  }
+
+  if (isPending) {
+    return <div>잠시만 기다려주세요!</div>
+  }
+  if (isError) {
+    return <div>에러가 발생했어요...</div>
+  }
 
   return (
     <S.Container>
@@ -22,19 +59,37 @@ export function UserProfile() {
             size="8rem"
             userId="userIdtest"
             imageUrl={data?.[0]?.profile_img}
+            disabledLink={true}
           />
           <S.ProfileDetailBox>
             <S.UserName>{data?.[0]?.nickname}</S.UserName>
             <S.IntruductionBox>{data?.[0]?.introduction}</S.IntruductionBox>
-            <S.SubscribeCountForOthers>
-              {data?.[0]?.subsc_count} 구독자
-            </S.SubscribeCountForOthers>
+            <S.SubscribeCount>{data?.[0]?.subsc_count} 구독자</S.SubscribeCount>
+            {currentUser!.id !== data?.[0].id &&
+              (isSubsc ? (
+                <Button
+                  type="button"
+                  className="subsc-cancel"
+                  onClick={handleSubscClick}
+                  disabled={isToggleSubscPending}>
+                  구독 취소
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={handleSubscClick}
+                  disabled={isToggleSubscPending}>
+                  구독
+                </Button>
+              ))}
           </S.ProfileDetailBox>
         </S.ProfileBox>
       </S.HeaderBoxForOther>
 
       <S.SeparatingBox>
-        <S.ShowTypes>플레이리스트</S.ShowTypes>
+        <S.PlayListBoxForOther>
+          {data?.[0]?.nickname} 님의 플레이리스트
+        </S.PlayListBoxForOther>
       </S.SeparatingBox>
 
       <S.PlayListsBox>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #149 

## 📋 작업 내용

- 유저프로필 페이지에 구독버튼을 추가하였습니다. 샘이님 view에 있는 로직 가져왔어요 ㅋㅋ 피그마에 없었는데 막상 완성하고 이것저것 보니 구독이 상세페이지에서만 가능한게 이상하더라구요. 버튼은 상세페이지에 있는걸 쓰려다가 어디에 놔도 어색하길래 마이페이지의 디자인과 유사하게 하였습니다.
- 서버의 데이터를 페칭하는데 있어서 
`  if (!data?.[0]?.id) {
    return <div>데이터가 페칭되고있지 않아요...</div>
  }` 
해당 조건문이 없을 경우에 페칭이 되는경우가 있고 안되는 경우가 있더라구요... 안되면 에러바운더리뜨고요. 어제 이것 때문에 한참 헤맸는데 쉽지않네요....
- 재호출이슈도 없어진것같아요. 
## 📸 스크린샷 (선택 사항)

![스크린샷 2025-01-17 100720](https://github.com/user-attachments/assets/5ea34e0c-7c55-46f6-ad4a-934935cf1b99)


## 📄 기타

이걸로 마지막 수정.... 같아요

엇 정신놓고해서 148번 커밋내용을 해당 브랜치까지 끌고왔었네요 .... 148번 승인되면 해당 pr 닫고 이걸로 merge하겠습니다
